### PR TITLE
CC-26461 Backporting password reset workflow improvements.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "spryker/merchant-user": "^1.0.0",
         "spryker/messenger": "^3.0.0",
         "spryker/security": "^1.5.0",
+        "spryker/security-blocker": "^1.0.0",
         "spryker/security-extension": "^1.0.0",
         "spryker/security-merchant-portal-gui-extension": "^1.0.0",
         "spryker/symfony": "^3.5.0",

--- a/src/Spryker/Shared/SecurityMerchantPortalGui/Transfer/security_merchant_portal_gui.transfer.xml
+++ b/src/Spryker/Shared/SecurityMerchantPortalGui/Transfer/security_merchant_portal_gui.transfer.xml
@@ -37,4 +37,17 @@
         <property name="type" type="string"/>
     </transfer>
 
+    <transfer name="SecurityCheckAuthContext">
+        <property name="type" type="string"/>
+        <property name="ip" type="string"/>
+        <property name="account" type="string"/>
+    </transfer>
+
+    <transfer name="SecurityCheckAuthResponse">
+        <property name="isBlocked" type="bool"/>
+        <property name="numberOfAttempts" type="int"/>
+        <property name="blockedFor" type="int"/>
+        <property name="securityCheckAuthContext" type="SecurityCheckAuthContext"/>
+    </transfer>
+
 </transfers>

--- a/src/Spryker/Zed/SecurityMerchantPortalGui/Communication/SecurityMerchantPortalGuiCommunicationFactory.php
+++ b/src/Spryker/Zed/SecurityMerchantPortalGui/Communication/SecurityMerchantPortalGuiCommunicationFactory.php
@@ -19,6 +19,7 @@ use Spryker\Zed\SecurityMerchantPortalGui\Communication\Security\MerchantUser;
 use Spryker\Zed\SecurityMerchantPortalGui\Communication\Security\MerchantUserInterface;
 use Spryker\Zed\SecurityMerchantPortalGui\Communication\Updater\SecurityTokenUpdater;
 use Spryker\Zed\SecurityMerchantPortalGui\Communication\Updater\SecurityTokenUpdaterInterface;
+use Spryker\Zed\SecurityMerchantPortalGui\Dependency\Client\SecurityMerchantPortalGuiToSecurityBlockerClientInterface;
 use Spryker\Zed\SecurityMerchantPortalGui\Dependency\Facade\SecurityMerchantPortalGuiToMerchantUserFacadeInterface;
 use Spryker\Zed\SecurityMerchantPortalGui\Dependency\Facade\SecurityMerchantPortalGuiToMessengerFacadeInterface;
 use Spryker\Zed\SecurityMerchantPortalGui\Dependency\Facade\SecurityMerchantPortalGuiToSecurityFacadeInterface;
@@ -142,5 +143,13 @@ class SecurityMerchantPortalGuiCommunicationFactory extends AbstractCommunicatio
     public function getMerchantUserLoginRestrictionPlugins(): array
     {
         return $this->getProvidedDependency(SecurityMerchantPortalGuiDependencyProvider::PLUGINS_MERCHANT_USER_LOGIN_RESTRICTION);
+    }
+
+    /**
+     * @return \Spryker\Zed\SecurityMerchantPortalGui\Dependency\Client\SecurityMerchantPortalGuiToSecurityBlockerClientInterface
+     */
+    public function getSecurityBlockerClient(): SecurityMerchantPortalGuiToSecurityBlockerClientInterface
+    {
+        return $this->getProvidedDependency(SecurityMerchantPortalGuiDependencyProvider::CLIENT_SECURITY_BLOCKER);
     }
 }

--- a/src/Spryker/Zed/SecurityMerchantPortalGui/Dependency/Client/SecurityMerchantPortalGuiToSecurityBlockerClientBridge.php
+++ b/src/Spryker/Zed/SecurityMerchantPortalGui/Dependency/Client/SecurityMerchantPortalGuiToSecurityBlockerClientBridge.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Spryker Marketplace License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\SecurityMerchantPortalGui\Dependency\Client;
+
+use Generated\Shared\Transfer\SecurityCheckAuthContextTransfer;
+use Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer;
+
+class SecurityMerchantPortalGuiToSecurityBlockerClientBridge implements SecurityMerchantPortalGuiToSecurityBlockerClientInterface
+{
+    /**
+     * @var \Spryker\Client\SecurityBlocker\SecurityBlockerClientInterface
+     */
+    protected $securityBlockerClient;
+
+    /**
+     * @param \Spryker\Client\SecurityBlocker\SecurityBlockerClientInterface $securityBlockerClient
+     */
+    public function __construct($securityBlockerClient)
+    {
+        $this->securityBlockerClient = $securityBlockerClient;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function incrementLoginAttemptCount(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer
+    {
+        return $this->securityBlockerClient->incrementLoginAttemptCount($securityCheckAuthContextTransfer);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isAccountBlocked(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer
+    {
+        return $this->securityBlockerClient->isAccountBlocked($securityCheckAuthContextTransfer);
+    }
+}

--- a/src/Spryker/Zed/SecurityMerchantPortalGui/Dependency/Client/SecurityMerchantPortalGuiToSecurityBlockerClientInterface.php
+++ b/src/Spryker/Zed/SecurityMerchantPortalGui/Dependency/Client/SecurityMerchantPortalGuiToSecurityBlockerClientInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Spryker Marketplace License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\SecurityMerchantPortalGui\Dependency\Client;
+
+use Generated\Shared\Transfer\SecurityCheckAuthContextTransfer;
+use Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer;
+
+interface SecurityMerchantPortalGuiToSecurityBlockerClientInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer
+     *
+     * @return \Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer
+     */
+    public function incrementLoginAttemptCount(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer
+     *
+     * @return \Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer
+     */
+    public function isAccountBlocked(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer;
+}

--- a/src/Spryker/Zed/SecurityMerchantPortalGui/SecurityMerchantPortalGuiConfig.php
+++ b/src/Spryker/Zed/SecurityMerchantPortalGui/SecurityMerchantPortalGuiConfig.php
@@ -27,6 +27,43 @@ class SecurityMerchantPortalGuiConfig extends AbstractBundleConfig
     protected const LOGIN_URL = '/security-merchant-portal-gui/login';
 
     /**
+     * @var string
+     */
+    protected const MERCHANT_PORTAL_SECURITY_BLOCKER_ENTITY_TYPE = 'customer';
+
+    /**
+     * @var bool
+     */
+    protected const MERCHANT_PORTAL_SECURITY_BLOCKER_ENABLED = false;
+
+    /**
+     * Specification:
+     * - Checks if the security blocker is enabled.
+     * - It is disabled by default.
+     *
+     * @api
+     *
+     * @return bool
+     */
+    public function isMerchantPortalSecurityBlockerEnabled(): bool
+    {
+        return static::MERCHANT_PORTAL_SECURITY_BLOCKER_ENABLED;
+    }
+
+    /**
+     * Specification:
+     * - Returns the entity identifier that is used to block the password resets.
+     *
+     * @api
+     *
+     * @return string
+     */
+    public function getMerchantPortalSecurityBlockerEntityType(): string
+    {
+        return static::MERCHANT_PORTAL_SECURITY_BLOCKER_ENTITY_TYPE;
+    }
+
+    /**
      * @api
      *
      * @return string

--- a/src/Spryker/Zed/SecurityMerchantPortalGui/SecurityMerchantPortalGuiDependencyProvider.php
+++ b/src/Spryker/Zed/SecurityMerchantPortalGui/SecurityMerchantPortalGuiDependencyProvider.php
@@ -9,6 +9,7 @@ namespace Spryker\Zed\SecurityMerchantPortalGui;
 
 use Spryker\Zed\Kernel\AbstractBundleDependencyProvider;
 use Spryker\Zed\Kernel\Container;
+use Spryker\Zed\SecurityMerchantPortalGui\Dependency\Client\SecurityMerchantPortalGuiToSecurityBlockerClientBridge;
 use Spryker\Zed\SecurityMerchantPortalGui\Dependency\Facade\SecurityMerchantPortalGuiToMerchantUserFacadeBridge;
 use Spryker\Zed\SecurityMerchantPortalGui\Dependency\Facade\SecurityMerchantPortalGuiToMessengerFacadeBridge;
 use Spryker\Zed\SecurityMerchantPortalGui\Dependency\Facade\SecurityMerchantPortalGuiToSecurityFacadeBridge;
@@ -46,6 +47,11 @@ class SecurityMerchantPortalGuiDependencyProvider extends AbstractBundleDependen
     public const SERVICE_SECURITY_TOKEN_STORAGE = 'security.token_storage';
 
     /**
+     * @var string
+     */
+    public const CLIENT_SECURITY_BLOCKER = 'CLIENT_SECURITY_BLOCKER';
+
+    /**
      * @param \Spryker\Zed\Kernel\Container $container
      *
      * @return \Spryker\Zed\Kernel\Container
@@ -57,10 +63,9 @@ class SecurityMerchantPortalGuiDependencyProvider extends AbstractBundleDependen
         $container = $this->addMerchantUserFacade($container);
         $container = $this->addMessengerFacade($container);
         $container = $this->addSecurityFacade($container);
-
         $container = $this->addTokenStorage($container);
-
         $container = $this->addMerchantUserLoginRestrictionPlugins($container);
+        $container = $this->addSecurityBlockerClient($container);
 
         return $container;
     }
@@ -75,6 +80,20 @@ class SecurityMerchantPortalGuiDependencyProvider extends AbstractBundleDependen
         $container = parent::provideBusinessLayerDependencies($container);
 
         $container = $this->addMerchantUserFacade($container);
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addSecurityBlockerClient(Container $container): Container
+    {
+        $container->set(static::CLIENT_SECURITY_BLOCKER, function (Container $container) {
+            return new SecurityMerchantPortalGuiToSecurityBlockerClientBridge($container->getLocator()->securityBlocker()->client());
+        });
 
         return $container;
     }


### PR DESCRIPTION
Branch: backport/2.1.1
Ticket: https://spryker.atlassian.net/browse/CC-26461
Version: 2.1.1
- Strategy: minor

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SecurityMerchantPortalGui | patch                 |                       |

-----------------------------------------

#### Module SecurityMerchantPortalGui

##### Change log

Improvements

- Adjusted `PasswordController::resetRequestAction()` with the behavior that password reset requests are silently blocked when requested too frequently within a short time. 
- Introduced `SecurityMerchantPortalGuiConfig::isMerchantPortalSecurityBlockerEnabled()` to enable or disable the blocking. It is enabled by default.
- Introduced `SecurityMerchantPortalGuiConfig::getMerchantPortalSecurityBlockerEntityType()` that returns the string used to identify the blocking type.
- Introduced `SecurityCheckAuthContext` transfer.
- Introduced `SecurityCheckAuthResponse` transfer.
- Added `SecurityBlockerClientInterface` to dependencies.
- Added `SecurityBlocker` module dependency.